### PR TITLE
(feat): obfuscate transactions and traces path params with config regex

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1211,24 +1211,40 @@ defaultConfig.definition = () => ({
   },
 
   /**
-   * Default URL obfuscation regex - will never match anything
+   * Obfuscates URL parameters
+   * for outgoing and incoming requests
+   * for distrubuted tracing attributes - both transaction and span attributes
+   * for transaction trace transaction details
    */
   url_obfuscation: {
+    /**
+     * Toggles whether to obfuscate URL parameters
+     */
     enabled: {
       formatter: boolean,
       default: false
     },
 
     regex: {
+      /**
+       * A regular expression to match URL parameters to obfuscate
+       */
       pattern: {
         formatter: regex,
         default: null
       },
 
+      /**
+       * A string containing RegEx flags to use when matching URL parameters
+       */
       flags: {
         default: null
       },
 
+      /**
+       * A string containing a replacement value for URL parameters
+       * can contain refferences to capture groups in the pattern
+       */
       replacement: {
         default: null
       }

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1238,7 +1238,7 @@ defaultConfig.definition = () => ({
        * A string containing RegEx flags to use when matching URL parameters
        */
       flags: {
-        default: null
+        default: ''
       },
 
       /**
@@ -1246,7 +1246,7 @@ defaultConfig.definition = () => ({
        * can contain refferences to capture groups in the pattern
        */
       replacement: {
-        default: null
+        default: ''
       }
     }
   }

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1220,11 +1220,17 @@ defaultConfig.definition = () => ({
     },
 
     regex: {
-      formatter: regex,
-      default: {
-        pattern: null,
-        flags: null,
-        replacement: null
+      pattern: {
+        formatter: regex,
+        default: null
+      },
+
+      flags: {
+        default: null
+      },
+
+      replacement: {
+        default: null
       }
     }
   }

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1223,8 +1223,8 @@ defaultConfig.definition = () => ({
       formatter: regex,
       default: {
         pattern: null,
-        flags: undefined,
-        replacement: undefined
+        flags: null,
+        replacement: null
       }
     }
   }

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1208,7 +1208,12 @@ defaultConfig.definition = () => ({
       formatter: boolean,
       default: false
     }
-  }
+  },
+
+  /**
+   * Default URL obfuscation regex - will never match anything
+   */
+  url_obfuscation_regex: '~^'
 })
 
 /**

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -6,7 +6,7 @@
 'use strict'
 
 const defaultConfig = module.exports
-const { array, int, float, boolean, object, objectList, allowList } = require('./formatters')
+const { array, int, float, boolean, object, objectList, allowList, regex } = require('./formatters')
 
 /**
  * A function that returns the definition of the agent configuration
@@ -1213,7 +1213,21 @@ defaultConfig.definition = () => ({
   /**
    * Default URL obfuscation regex - will never match anything
    */
-  url_obfuscation_regex: '~^'
+  url_obfuscation: {
+    enabled: {
+      formatter: boolean,
+      default: false
+    },
+
+    regex: {
+      formatter: regex,
+      default: {
+        pattern: null,
+        flags: undefined,
+        replacement: undefined
+      }
+    }
+  }
 })
 
 /**

--- a/lib/config/formatters.js
+++ b/lib/config/formatters.js
@@ -106,3 +106,19 @@ formatters.objectList = function objectList(val, logger) {
 formatters.allowList = function allowList(list, val) {
   return list.includes(val) ? val : list[0]
 }
+
+/**
+ * Parse a config setting as a regex
+ *
+ * @param {string} val valid regex
+ * @param {logger} logger agent logger instance
+ * @returns {RegExp} regex
+ */
+formatters.regex = function regex(val, logger) {
+  try {
+    return new RegExp(val)
+  } catch (error) {
+    logger.error(`New Relic configurator could not validate regex: ${val}`)
+    logger.error(error.stack)
+  }
+}

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -993,7 +993,7 @@ Config.prototype._fromPassed = function _fromPassed(external, internal, arbitrar
       return
     }
 
-    if (typeof node === 'object' && !Array.isArray(node)) {
+    if (typeof node === 'object' && !Array.isArray(node) && !(node instanceof RegExp)) {
       // is top level and can have arbitrary keys
       const allowArbitrary = internal === this || HAS_ARBITRARY_KEYS.has(key)
       this._fromPassed(node, internal[key], allowArbitrary)
@@ -1095,7 +1095,13 @@ Config.prototype._fromEnvironment = function _fromEnvironment(
       setFromEnv({ config, key, envVar, paths })
     } else if (type === 'object') {
       if (value.hasOwnProperty('env')) {
-        setFromEnv({ config, key, envVar: value.env, paths, formatter: value.formatter })
+        setFromEnv({
+          config,
+          key,
+          envVar: value.env,
+          paths,
+          formatter: value.formatter
+        })
       } else if (value.hasOwnProperty('default')) {
         const envVar = deriveEnvVar(key, paths)
         setFromEnv({ config, key, envVar, formatter: value.formatter, paths })

--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -146,7 +146,7 @@ function instrumentRequest(agent, opts, makeRequest, hostname, segment) {
   maybeAddDtCatHeaders(agent, transaction, outboundHeaders, !!opts?.headers?.[symbols.disableDT])
   opts.headers = assignOutgoingHeaders(opts.headers, outboundHeaders)
 
-  const request = applySegment(agent, opts, makeRequest, hostname, segment)
+  const request = applySegment(opts, makeRequest, hostname, segment)
 
   instrumentRequestEmit(agent, hostname, segment, request)
 
@@ -205,18 +205,17 @@ function assignOutgoingHeaders(currentHeaders, outboundHeaders) {
 /**
  * Starts the http outbound segment and attaches relevant attributes to the segment/span.
  *
- * @param {Agent} agent New Relic agent
  * @param {string|object} opts a url string or HTTP request options
  * @param {Function} makeRequest function to make request
  * @param {string} hostname host of outbound request
  * @param {TraceSegment} segment outbound http segment
  * @returns {http.IncomingMessage} request actual http outbound request
  */
-function applySegment(agent, opts, makeRequest, hostname, segment) {
+function applySegment(opts, makeRequest, hostname, segment) {
   segment.start()
   const request = makeRequest(opts)
   const parsed = urltils.scrubAndParseParameters(request.path)
-  parsed.path = urltils.obfuscatePath(agent.config, parsed.path)
+  parsed.path = urltils.obfuscatePath(segment.transaction.agent.config, parsed.path)
   const proto = parsed.protocol || opts.protocol || 'http:'
   segment.name += parsed.path
   request[symbols.segment] = segment

--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -146,7 +146,7 @@ function instrumentRequest(agent, opts, makeRequest, hostname, segment) {
   maybeAddDtCatHeaders(agent, transaction, outboundHeaders, !!opts?.headers?.[symbols.disableDT])
   opts.headers = assignOutgoingHeaders(opts.headers, outboundHeaders)
 
-  const request = applySegment(opts, makeRequest, hostname, segment)
+  const request = applySegment(agent, opts, makeRequest, hostname, segment)
 
   instrumentRequestEmit(agent, hostname, segment, request)
 
@@ -205,16 +205,18 @@ function assignOutgoingHeaders(currentHeaders, outboundHeaders) {
 /**
  * Starts the http outbound segment and attaches relevant attributes to the segment/span.
  *
+ * @param {Agent} agent New Relic agent
  * @param {string|object} opts a url string or HTTP request options
  * @param {Function} makeRequest function to make request
  * @param {string} hostname host of outbound request
  * @param {TraceSegment} segment outbound http segment
  * @returns {http.IncomingMessage} request actual http outbound request
  */
-function applySegment(opts, makeRequest, hostname, segment) {
+function applySegment(agent, opts, makeRequest, hostname, segment) {
   segment.start()
   const request = makeRequest(opts)
   const parsed = urltils.scrubAndParseParameters(request.path)
+  parsed.path = urltils.obfuscatePath(agent.config, parsed.path)
   const proto = parsed.protocol || opts.protocol || 'http:'
   segment.name += parsed.path
   request[symbols.segment] = segment

--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -86,7 +86,7 @@ function wrapEmitWithTransaction(agent, emit, isHTTPS) {
 
     // the error tracer needs a URL for tracing, even though naming overwrites
     transaction.parsedUrl = url.parse(request.url, true)
-    transaction.url = transaction.parsedUrl.pathname
+    transaction.url = urltils.obfuscatePath(agent.config, transaction.parsedUrl.pathname)
     transaction.verb = request.method
 
     // URL is sent as an agent attribute with transaction events

--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -86,7 +86,7 @@ function wrapEmitWithTransaction(agent, emit, isHTTPS) {
 
     // the error tracer needs a URL for tracing, even though naming overwrites
     transaction.parsedUrl = url.parse(request.url, true)
-    transaction.url = urltils.obfuscatePath(agent.config, transaction.parsedUrl.pathname)
+    transaction.url = urltils.obfuscatePath(agent.config, transaction.parsedUrl.path)
     transaction.verb = request.method
 
     // URL is sent as an agent attribute with transaction events

--- a/lib/transaction/trace/index.js
+++ b/lib/transaction/trace/index.js
@@ -8,7 +8,7 @@
 /* eslint sonarjs/cognitive-complexity: ["error", 19] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
 
 const codec = require('../../util/codec')
-const urlutils = require('../../util/urltils')
+const urltils = require('../../util/urltils')
 const Segment = require('./segment')
 const { Attributes, MAXIMUM_CUSTOM_ATTRIBUTES } = require('../../attributes')
 const logger = require('../../logger').child({ component: 'trace' })
@@ -331,7 +331,7 @@ Trace.prototype._getRequestUri = function _getRequestUri() {
   let requestUri = null // must be null if excluded
   if (canAddUri) {
     // obfuscate the path if config is set
-    const url = urlutils.obfuscatePath(this.transaction.agent.config, this.transaction.url)
+    const url = urltils.obfuscatePath(this.transaction.agent.config, this.transaction.url)
     requestUri = url || UNKNOWN_URI_PLACEHOLDER
   }
 

--- a/lib/transaction/trace/index.js
+++ b/lib/transaction/trace/index.js
@@ -8,6 +8,7 @@
 /* eslint sonarjs/cognitive-complexity: ["error", 19] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
 
 const codec = require('../../util/codec')
+const urlutils = require('../../util/urltils')
 const Segment = require('./segment')
 const { Attributes, MAXIMUM_CUSTOM_ATTRIBUTES } = require('../../attributes')
 const logger = require('../../logger').child({ component: 'trace' })
@@ -329,7 +330,9 @@ Trace.prototype._getRequestUri = function _getRequestUri() {
   const canAddUri = this.attributes.hasValidDestination(DESTINATIONS.TRANS_TRACE, REQUEST_URI_KEY)
   let requestUri = null // must be null if excluded
   if (canAddUri) {
-    requestUri = this.transaction.url || UNKNOWN_URI_PLACEHOLDER
+    // obfuscate the path if config is set
+    const url = urlutils.obfuscatePath(this.transaction.agent.config, this.transaction.url)
+    requestUri = url || UNKNOWN_URI_PLACEHOLDER
   }
 
   return requestUri

--- a/lib/util/urltils.js
+++ b/lib/util/urltils.js
@@ -171,12 +171,8 @@ module.exports = {
    * @returns {string} The obfuscated path or the original path
    */
   obfuscatePath: function obfuscatePath(config, path) {
-    if (typeof path !== 'string') {
-      return path
-    }
-
     const { enabled, regex } = config.url_obfuscation
-    if (!enabled || !regex) {
+    if (typeof path !== 'string' || !enabled || !regex) {
       return path
     }
 

--- a/lib/util/urltils.js
+++ b/lib/util/urltils.js
@@ -166,17 +166,19 @@ module.exports = {
    * Obfuscates path parameters with regex from config
    *
    * @param {Config} config The configuration containing the regex
-   * @param {string} requestPath The Path to be obfuscated
-   * @returns {string} The obfuscated path
+   * @param {string} path The path to be obfuscated
+   * @returns {string} The obfuscated path or the original path
    */
-  obfuscatePath: function obfuscatePath(config, requestPath) {
-    if (typeof requestPath === 'string') {
-      const regex = config.url_obfuscation_regex
-      if (regex) {
-        return (requestPath = requestPath.replace(regex, '/***'))
+  obfuscatePath: function obfuscatePath(config, path) {
+    // TODO: handle SyntaxError: Invalid regular expression
+    if (typeof path === 'string') {
+      const { enabled, regex } = config.url_obfuscation
+      if (enabled) {
+        const pattern = new RegExp(regex.pattern, regex.flags)
+        return (path = path.replace(pattern, `/${regex.replacement}`))
       }
     }
-    return requestPath
+    return path
   },
 
   /**

--- a/lib/util/urltils.js
+++ b/lib/util/urltils.js
@@ -163,6 +163,23 @@ module.exports = {
   },
 
   /**
+   * Obfuscates path parameters with regex from config
+   *
+   * @param {Config} config The configuration containing the regex
+   * @param {string} requestPath The Path to be obfuscated
+   * @returns {string} The obfuscated path
+   */
+  obfuscatePath: function obfuscatePath(config, requestPath) {
+    if (typeof requestPath === 'string') {
+      const regex = config.url_obfuscation_regex
+      if (regex) {
+        return (requestPath = requestPath.replace(regex, '/***'))
+      }
+    }
+    return requestPath
+  },
+
+  /**
    * Copy a set of request parameters from one object to another,
    * but do not overwrite any existing parameters in destination,
    * including parameters set to null or undefined.

--- a/lib/util/urltils.js
+++ b/lib/util/urltils.js
@@ -171,14 +171,20 @@ module.exports = {
    */
   obfuscatePath: function obfuscatePath(config, path) {
     // TODO: handle SyntaxError: Invalid regular expression
-    if (typeof path === 'string') {
-      const { enabled, regex } = config.url_obfuscation
-      if (enabled) {
-        const pattern = new RegExp(regex.pattern, regex.flags)
-        return (path = path.replace(pattern, `/${regex.replacement}`))
-      }
+    if (typeof path !== 'string') {
+      return path
     }
-    return path
+
+    const { enabled, regex } = config.url_obfuscation
+    if (!enabled || !regex) {
+      return path
+    }
+
+    const { pattern, flags, replacement } = regex
+    const f = !flags ? '' : flags
+    const r = !replacement ? '' : replacement
+    const regexPattern = new RegExp(pattern, f)
+    return path.replace(regexPattern, `/${r}`)
   },
 
   /**

--- a/lib/util/urltils.js
+++ b/lib/util/urltils.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const url = require('url')
+const logger = require('../logger').child({ component: 'urltils' })
 
 const LOCALHOST_NAMES = {
   'localhost': true,
@@ -170,7 +171,6 @@ module.exports = {
    * @returns {string} The obfuscated path or the original path
    */
   obfuscatePath: function obfuscatePath(config, path) {
-    // TODO: handle SyntaxError: Invalid regular expression
     if (typeof path !== 'string') {
       return path
     }
@@ -180,11 +180,14 @@ module.exports = {
       return path
     }
 
-    const { pattern, flags, replacement } = regex
-    const f = !flags ? '' : flags
-    const r = !replacement ? '' : replacement
-    const regexPattern = new RegExp(pattern, f)
-    return path.replace(regexPattern, `/${r}`)
+    const { pattern, flags = '', replacement = '' } = regex
+    try {
+      const regexPattern = new RegExp(pattern, flags)
+      return path.replace(regexPattern, `/${replacement}`)
+    } catch (e) {
+      logger.warn('Invalid regular expression for url_obfuscation.regex.pattern', pattern)
+      return path
+    }
   },
 
   /**

--- a/lib/util/urltils.js
+++ b/lib/util/urltils.js
@@ -179,7 +179,7 @@ module.exports = {
     const { pattern, flags = '', replacement = '' } = regex
     try {
       const regexPattern = new RegExp(pattern, flags)
-      return path.replace(regexPattern, `/${replacement}`)
+      return path.replace(regexPattern, replacement)
     } catch (e) {
       logger.warn('Invalid regular expression for url_obfuscation.regex.pattern', pattern)
       return path

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -270,4 +270,16 @@ tap.test('with default properties', (t) => {
     t.equal(configuration.code_level_metrics.enabled, false)
     t.end()
   })
+
+  t.test('should default `url_obfuscation` accordingly', (t) => {
+    t.same(configuration.url_obfuscation, {
+      enabled: false,
+      regex: {
+        pattern: null,
+        flags: undefined,
+        replacement: undefined
+      }
+    })
+    t.end()
+  })
 })

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -276,8 +276,8 @@ tap.test('with default properties', (t) => {
       enabled: false,
       regex: {
         pattern: null,
-        flags: null,
-        replacement: null
+        flags: '',
+        replacement: ''
       }
     })
     t.end()

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -276,8 +276,8 @@ tap.test('with default properties', (t) => {
       enabled: false,
       regex: {
         pattern: null,
-        flags: undefined,
-        replacement: undefined
+        flags: null,
+        replacement: null
       }
     })
     t.end()

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -682,7 +682,6 @@ tap.test('when overriding configuration values via environment variables', (t) =
 
   t.test('shold pick up url_obfuscation.regex parameters', (t) => {
     const env = {
-      // NEW_RELIC_URL_OBFUSCATION_ENABLED: "true",
       NEW_RELIC_URL_OBFUSCATION_REGEX_PATTERN: 'regex',
       NEW_RELIC_URL_OBFUSCATION_REGEX_FLAGS: 'g',
       NEW_RELIC_URL_OBFUSCATION_REGEX_REPLACEMENT: 'replacement'

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -680,7 +680,7 @@ tap.test('when overriding configuration values via environment variables', (t) =
     })
   })
 
-  t.test('shold pick up url_obfuscation.regex parameters', (t) => {
+  t.test('should pick up url_obfuscation.regex parameters', (t) => {
     const env = {
       NEW_RELIC_URL_OBFUSCATION_REGEX_PATTERN: 'regex',
       NEW_RELIC_URL_OBFUSCATION_REGEX_FLAGS: 'g',
@@ -691,6 +691,17 @@ tap.test('when overriding configuration values via environment variables', (t) =
       t.same(config.url_obfuscation.regex.pattern, /regex/)
       t.equal(config.url_obfuscation.regex.flags, 'g')
       t.equal(config.url_obfuscation.regex.replacement, 'replacement')
+      t.end()
+    })
+  })
+
+  t.test('should set regex to undefined if invalid regex', (t) => {
+    const env = {
+      NEW_RELIC_URL_OBFUSCATION_REGEX_PATTERN: '['
+    }
+
+    idempotentEnv(env, (config) => {
+      t.notOk(config.url_obfuscation.regex.pattern)
       t.end()
     })
   })

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -369,10 +369,15 @@ tap.test('when overriding configuration values via environment variables', (t) =
   })
 
   t.test('should pick up which status codes are expectedd when using a range', (t) => {
-    idempotentEnv({ NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES: '401, 420-421, 502' }, (tc) => {
-      t.same(tc.error_collector.expected_status_codes, [401, 420, 421, 502])
-      t.end()
-    })
+    idempotentEnv(
+      {
+        NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES: '401, 420-421, 502'
+      },
+      (tc) => {
+        t.same(tc.error_collector.expected_status_codes, [401, 420, 421, 502])
+        t.end()
+      }
+    )
   })
 
   t.test('should not add codes given with invalid range', (t) => {
@@ -625,7 +630,9 @@ tap.test('when overriding configuration values via environment variables', (t) =
   t.test('should pick up custom esm entrypoint configuration', (t) => {
     const customEntryPoint = '/patht/to/custom-instrumentation.mjs'
     idempotentEnv(
-      { NEW_RELIC_API_ESM_CUSTOM_INSTRUMENTATION_ENTRYPOINT: customEntryPoint },
+      {
+        NEW_RELIC_API_ESM_CUSTOM_INSTRUMENTATION_ENTRYPOINT: customEntryPoint
+      },
       function (tc) {
         t.equal(tc.api.esm.custom_instrumentation_entrypoint, customEntryPoint)
         t.end()
@@ -658,6 +665,33 @@ tap.test('when overriding configuration values via environment variables', (t) =
   t.test('should pick up code_level_metrics.enabled', (t) => {
     idempotentEnv({ NEW_RELIC_CODE_LEVEL_METRICS_ENABLED: 'true' }, function (tc) {
       t.equal(tc.code_level_metrics.enabled, true)
+      t.end()
+    })
+  })
+
+  t.test('should pick up url_obfuscation.enabled', (t) => {
+    const env = {
+      NEW_RELIC_URL_OBFUSCATION_ENABLED: 'true'
+    }
+
+    idempotentEnv(env, (config) => {
+      t.equal(config.url_obfuscation.enabled, true)
+      t.end()
+    })
+  })
+
+  t.test('shold pick up url_obfuscation.regex parameters', (t) => {
+    const env = {
+      // NEW_RELIC_URL_OBFUSCATION_ENABLED: "true",
+      NEW_RELIC_URL_OBFUSCATION_REGEX_PATTERN: 'regex',
+      NEW_RELIC_URL_OBFUSCATION_REGEX_FLAGS: 'g',
+      NEW_RELIC_URL_OBFUSCATION_REGEX_REPLACEMENT: 'replacement'
+    }
+
+    idempotentEnv(env, (config) => {
+      t.same(config.url_obfuscation.regex.pattern, /regex/)
+      t.equal(config.url_obfuscation.regex.flags, 'g')
+      t.equal(config.url_obfuscation.regex.replacement, 'replacement')
       t.end()
     })
   })

--- a/test/unit/config/config-formatters.test.js
+++ b/test/unit/config/config-formatters.test.js
@@ -156,4 +156,24 @@ tap.test('config formatters', (t) => {
       t.end()
     })
   })
+
+  tap.test('regex', (t) => {
+    t.autoend()
+
+    t.test('should return regex if valid', (t) => {
+      const val = '/hello/'
+      const result = formatters.regex(val)
+      t.same(result, /\/hello\//)
+      t.end()
+    })
+
+    t.test('should log error and return null if regex is invalid', (t) => {
+      const loggerMock = { error: sinon.stub() }
+      const val = '[a-z'
+      t.notOk(formatters.regex(val, loggerMock))
+      t.equal(loggerMock.error.args[0][0], `New Relic configurator could not validate regex: [a-z`)
+      t.match(loggerMock.error.args[1][0], /SyntaxError: Invalid regular expression/)
+      t.end()
+    })
+  })
 })

--- a/test/unit/instrumentation/http/http.test.js
+++ b/test/unit/instrumentation/http/http.test.js
@@ -322,6 +322,30 @@ test('built-in http module instrumentation', (t) => {
       }
     )
 
+    t.test('when url_obfuscation_regex is set, obfuscate segment url attributes', (t) => {
+      agent.config.allow_all_headers = true
+      agent.config.url_obfuscation_regex = /.*/
+      transaction = null
+      makeRequest(
+        {
+          port: 8123,
+          host: 'localhost',
+          path: '/foo4/bar4',
+          method: 'GET'
+        },
+        finish
+      )
+
+      function finish() {
+        const segment = transaction.baseSegment
+        const spanAttributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
+
+        t.equal(spanAttributes['request.uri'], '/***')
+
+        t.end()
+      }
+    })
+
     t.test('successful request', (t) => {
       transaction = null
       const refererUrl = 'https://www.google.com/search/cats?scrubbed=false'
@@ -687,7 +711,7 @@ test('built-in http module instrumentation', (t) => {
       const traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00'
       const priority = 0.789
       // eslint-disable-next-line
-        const tracestate = `190@nr=0-0-709288-8599547-f85f42fd82a4cf1d-164d3b4b0d09cb05-1-${priority}-1563574856827`
+        const tracestate = `190@nr=0-0-709288-8599547-f85f42fd82a4cf1d-164d3b4b0d09cb05-1-${priority}-1563574856827`;
       http = require('http')
       agent.config.trusted_account_key = 190
 

--- a/test/unit/instrumentation/http/http.test.js
+++ b/test/unit/instrumentation/http/http.test.js
@@ -327,7 +327,7 @@ test('built-in http module instrumentation', (t) => {
         enabled: true,
         regex: {
           pattern: '.*',
-          replacement: '***'
+          replacement: '/***'
         }
       }
       transaction = null

--- a/test/unit/instrumentation/http/http.test.js
+++ b/test/unit/instrumentation/http/http.test.js
@@ -322,9 +322,14 @@ test('built-in http module instrumentation', (t) => {
       }
     )
 
-    t.test('when url_obfuscation_regex is set, obfuscate segment url attributes', (t) => {
-      agent.config.allow_all_headers = true
-      agent.config.url_obfuscation_regex = /.*/
+    t.test('when url_obfuscation regex pattern is set, obfuscate segment url attributes', (t) => {
+      agent.config.url_obfuscation = {
+        enabled: true,
+        regex: {
+          pattern: '.*',
+          replacement: '***'
+        }
+      }
       transaction = null
       makeRequest(
         {

--- a/test/unit/instrumentation/http/outbound.test.js
+++ b/test/unit/instrumentation/http/outbound.test.js
@@ -75,10 +75,16 @@ tap.test('instrumentOutbound', (t) => {
     t.end()
   })
 
-  t.test('should obfuscate url path if url_obfuscation_regex is set', (t) => {
+  t.test('should obfuscate url path if url_obfuscation regex pattern is set', (t) => {
     helper.unloadAgent(agent)
     agent = helper.loadMockedAgent({
-      url_obfuscation_regex: /.*/
+      url_obfuscation: {
+        enabled: true,
+        regex: {
+          pattern: '.*',
+          replacement: '***'
+        }
+      }
     })
     const req = new events.EventEmitter()
     helper.runInTransaction(agent, function (transaction) {

--- a/test/unit/instrumentation/http/outbound.test.js
+++ b/test/unit/instrumentation/http/outbound.test.js
@@ -82,7 +82,7 @@ tap.test('instrumentOutbound', (t) => {
         enabled: true,
         regex: {
           pattern: '.*',
-          replacement: '***'
+          replacement: '/***'
         }
       }
     })

--- a/test/unit/trace.test.js
+++ b/test/unit/trace.test.js
@@ -774,7 +774,7 @@ tap.test('should set URI to /Unknown when URL is not known/set on transaction', 
 })
 
 tap.test('should obfuscate URI using regex when pattern is set', async (t) => {
-  const URL = '/abc/123/def'
+  const URL = '/abc/123/def/456/ghi'
   const agent = helper.loadMockedAgent({
     url_obfuscation: {
       enabled: true,
@@ -801,7 +801,7 @@ tap.test('should obfuscate URI using regex when pattern is set', async (t) => {
 
   const traceJSON = await trace.generateJSON()
   const { 3: requestUri } = traceJSON
-  t.equal(requestUri, '/abc/***/def')
+  t.equal(requestUri, '/abc/***/def/***/ghi')
   t.end()
 })
 

--- a/test/unit/trace.test.js
+++ b/test/unit/trace.test.js
@@ -115,7 +115,7 @@ describe('Trace', function () {
           enabled: true,
           regex: {
             pattern: '.*',
-            replacement: '***'
+            replacement: '/***'
           }
         }
 
@@ -779,9 +779,9 @@ tap.test('should obfuscate URI using regex when pattern is set', async (t) => {
     url_obfuscation: {
       enabled: true,
       regex: {
-        pattern: '/[0-9]+',
+        pattern: '/[0-9]+/',
         flags: 'g',
-        replacement: '***'
+        replacement: '/***/'
       }
     }
   })

--- a/test/unit/urltils.test.js
+++ b/test/unit/urltils.test.js
@@ -273,4 +273,66 @@ describe('NR URL utilities', function () {
       })
     })
   })
+
+  describe('obfuscates path by regex', function () {
+    let config
+    let path
+
+    beforeEach(function () {
+      config = {
+        url_obfuscation: {
+          enabled: false,
+          regex: {
+            pattern: null,
+            flags: undefined,
+            replacement: undefined
+          }
+        }
+      }
+      path = '/foo/123/bar/456/baz/789'
+    })
+
+    it('should not obfuscate path by default', function () {
+      expect(urltils.obfuscatePath(config, path)).equal(path)
+    })
+
+    it('should not obfuscate if obfuscation is enabled but pattern is not set', function () {
+      config.url_obfuscation.enabled = true
+      expect(urltils.obfuscatePath(config, path)).equal(path)
+    })
+
+    it('should not obfuscate if obfuscation is enabled but pattern is invalid', function () {
+      config.url_obfuscation.enabled = true
+      config.url_obfuscation.regex.pattern = '/foo/bar/baz/[0-9]+'
+      expect(urltils.obfuscatePath(config, path)).equal(path)
+    })
+
+    it('should obfuscate with `undefined` if replacement is not set and pattern is set', function () {
+      config.url_obfuscation.enabled = true
+      config.url_obfuscation.regex.pattern = '/foo/[0-9]+/bar/[0-9]+/baz/[0-9]+'
+      expect(urltils.obfuscatePath(config, path)).equal('/undefined')
+    })
+
+    it('should obfuscate with replacement if replacement is set and pattern is set', function () {
+      config.url_obfuscation.enabled = true
+      config.url_obfuscation.regex.pattern = '/foo/[0-9]+/bar/[0-9]+/baz/[0-9]+'
+      config.url_obfuscation.regex.replacement = '***'
+      expect(urltils.obfuscatePath(config, path)).equal('/***')
+    })
+
+    it('should obfuscate as expected with capture groups pattern over strings', function () {
+      config.url_obfuscation.enabled = true
+      config.url_obfuscation.regex.pattern = '(/foo/)(.*)(/bar/)(.*)(/baz/)(.*)'
+      config.url_obfuscation.regex.replacement = '$1***$3***$5***'
+      expect(urltils.obfuscatePath(config, path)).equal('//foo/***/bar/***/baz/***')
+    })
+
+    it('shoould obfuscate as expected with regex patterns and flags', function () {
+      config.url_obfuscation.enabled = true
+      config.url_obfuscation.regex.pattern = '/[0-9]+'
+      config.url_obfuscation.regex.flags = 'g'
+      config.url_obfuscation.regex.replacement = '***'
+      expect(urltils.obfuscatePath(config, path)).equal('/foo/***/bar/***/baz/***')
+    })
+  })
 })

--- a/test/unit/urltils.test.js
+++ b/test/unit/urltils.test.js
@@ -12,10 +12,22 @@ require('tap').mochaGlobals()
 const expect = require('chai').expect
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
-const urltils = require('../../lib/util/urltils')
 const url = require('url')
 
 describe('NR URL utilities', function () {
+  let loggerStub
+  let urltils
+  beforeEach(function () {
+    loggerStub = {
+      warn: sinon.stub()
+    }
+    urltils = proxyquire('../../lib/util/urltils', {
+      '../logger': {
+        child: sinon.stub().returns(loggerStub)
+      }
+    })
+  })
+
   describe('scrubbing URLs', function () {
     it('should return "/" if there\'s no leading slash on the path', function () {
       expect(urltils.scrub('?t_u=http://some.com/o/p')).equal('/')
@@ -279,24 +291,8 @@ describe('NR URL utilities', function () {
   describe('obfuscates path by regex', function () {
     let config
     let path
-    let loggerStub
 
-    beforeEach(function () {
-      loggerStub = {
-        './util/logger': function () {
-          return { warn: sinon.spy() }
-        },
-        'child': function () {
-          return {
-            logger: {
-              warn: sinon.spy()
-            }
-          }
-        },
-        'warn': sinon.spy()
-      }
-      proxyquire('../../lib/util/urltils', { '../logger': loggerStub })
-
+    beforeEach(() => {
       config = {
         url_obfuscation: {
           enabled: false,

--- a/test/unit/urltils.test.js
+++ b/test/unit/urltils.test.js
@@ -324,13 +324,13 @@ describe('NR URL utilities', function () {
     it('should obfuscate with empty string `` if replacement is not set and pattern is set', function () {
       config.url_obfuscation.enabled = true
       config.url_obfuscation.regex.pattern = '/foo/[0-9]+/bar/[0-9]+/baz/[0-9]+'
-      expect(urltils.obfuscatePath(config, path)).equal('/')
+      expect(urltils.obfuscatePath(config, path)).equal('')
     })
 
     it('should obfuscate with replacement if replacement is set and pattern is set', function () {
       config.url_obfuscation.enabled = true
       config.url_obfuscation.regex.pattern = '/foo/[0-9]+/bar/[0-9]+/baz/[0-9]+'
-      config.url_obfuscation.regex.replacement = '***'
+      config.url_obfuscation.regex.replacement = '/***'
       expect(urltils.obfuscatePath(config, path)).equal('/***')
     })
 
@@ -338,12 +338,12 @@ describe('NR URL utilities', function () {
       config.url_obfuscation.enabled = true
       config.url_obfuscation.regex.pattern = '(/foo/)(.*)(/bar/)(.*)(/baz/)(.*)'
       config.url_obfuscation.regex.replacement = '$1***$3***$5***'
-      expect(urltils.obfuscatePath(config, path)).equal('//foo/***/bar/***/baz/***')
+      expect(urltils.obfuscatePath(config, path)).equal('/foo/***/bar/***/baz/***')
     })
 
     it('should obfuscate as expected with regex patterns and flags', function () {
       config.url_obfuscation.enabled = true
-      config.url_obfuscation.regex.pattern = '/[0-9]+'
+      config.url_obfuscation.regex.pattern = '[0-9]+'
       config.url_obfuscation.regex.flags = 'g'
       config.url_obfuscation.regex.replacement = '***'
       expect(urltils.obfuscatePath(config, path)).equal('/foo/***/bar/***/baz/***')

--- a/test/unit/urltils.test.js
+++ b/test/unit/urltils.test.js
@@ -284,8 +284,8 @@ describe('NR URL utilities', function () {
           enabled: false,
           regex: {
             pattern: null,
-            flags: undefined,
-            replacement: undefined
+            flags: null,
+            replacement: null
           }
         }
       }
@@ -307,10 +307,10 @@ describe('NR URL utilities', function () {
       expect(urltils.obfuscatePath(config, path)).equal(path)
     })
 
-    it('should obfuscate with `undefined` if replacement is not set and pattern is set', function () {
+    it('should obfuscate with empty string `` if replacement is not set and pattern is set', function () {
       config.url_obfuscation.enabled = true
       config.url_obfuscation.regex.pattern = '/foo/[0-9]+/bar/[0-9]+/baz/[0-9]+'
-      expect(urltils.obfuscatePath(config, path)).equal('/undefined')
+      expect(urltils.obfuscatePath(config, path)).equal('/')
     })
 
     it('should obfuscate with replacement if replacement is set and pattern is set', function () {


### PR DESCRIPTION
Changes:

Based on the `url_obfuscation_regex` param from the `newrelic.js` config file.
- obfuscate `request.uri`
- obfuscate `http.url` (path part only)

For Transactions and Distributed Tracing (for incoming and outgoing http requests)

It also obfuscates `attributes` (with the same names as above) for Distributed Tracing (Spans and root of the transaction)

Adds Transaction Trace details `url` obfuscation.


<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
